### PR TITLE
fix:Change to restful url - User

### DIFF
--- a/src/main/java/orangetaxiteam/cocoman/application/UserApplicationService.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/UserApplicationService.java
@@ -11,9 +11,11 @@ import org.springframework.stereotype.Service;
 import orangetaxiteam.cocoman.application.dto.UserCreateRequestDTO;
 import orangetaxiteam.cocoman.application.dto.UserDTO;
 import orangetaxiteam.cocoman.application.dto.UserSignInDTO;
+import orangetaxiteam.cocoman.application.dto.UserUpdateRequestDTO;
 import orangetaxiteam.cocoman.config.JwtTokenProvider;
 import orangetaxiteam.cocoman.domain.User;
 import orangetaxiteam.cocoman.domain.UserService;
+
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -178,4 +180,23 @@ public class UserApplicationService {
             return null;
         }
     }
+    
+    public UserDTO findById(Long id) {
+		return UserDTO.fromDAO(userService.findById(id).orElseThrow(() -> new InputValueValidationException("invalid user id")));
+	}
+	
+	public UserDTO updateUser(Long id, UserUpdateRequestDTO userUpdateRequestDTO) {
+		return UserDTO.fromDAO(userService.update(id
+													, userUpdateRequestDTO.getRoles()
+													, userUpdateRequestDTO.getAge()
+													, userUpdateRequestDTO.getGender()
+													, userUpdateRequestDTO.getPhoneNum()
+													, userUpdateRequestDTO.getProfileImg()
+													, userUpdateRequestDTO.getPushToken())
+												);
+	}
+	
+	public void deleteUser(Long id) {
+		userService.delete(id);
+	}
 }

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/UserDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/UserDTO.java
@@ -1,6 +1,9 @@
 package orangetaxiteam.cocoman.application.dto;
 
+
 import java.time.LocalDateTime;
+
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -44,4 +47,5 @@ public class UserDTO {
 
         return userDTO;
     }
+
 }

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/UserUpdateRequestDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/UserUpdateRequestDTO.java
@@ -1,0 +1,23 @@
+package orangetaxiteam.cocoman.application.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserUpdateRequestDTO {
+
+	private List<String> roles;
+	private int age;
+	private String gender;
+	private String phoneNum;
+	private String profileImg;
+	private String pushToken;
+
+}

--- a/src/main/java/orangetaxiteam/cocoman/domain/UserService.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/UserService.java
@@ -1,13 +1,22 @@
 package orangetaxiteam.cocoman.domain;
 
+
 import orangetaxiteam.cocoman.application.dto.UserDTO;
 import orangetaxiteam.cocoman.web.exceptions.InputValueValidationException;
 import org.hibernate.cfg.NotYetImplementedException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import orangetaxiteam.cocoman.web.exceptions.InputValueValidationException;
+
 @Service
+
 public class UserService {
 
     private final UserRepository userRepository;
@@ -56,5 +65,28 @@ public class UserService {
 
     public User findById(String id){
         return userRepository.findById(id).orElseThrow(() -> new InputValueValidationException("invalid user id"));
+        
+        
     }
+    
+    public User update(Long id, List<String> roles, int age, String gender, String phoneNum, String profileImg, String pushToken) {
+		User user = findById(id).orElseThrow(() -> new InputValueValidationException("invalid user id"));
+		return userRepository.save(User.builder()
+									.id(id)
+									.username(user.getUsername())
+									.password(user.getPassword())
+									.roles(roles)
+									.age(age)
+									.gender(gender)
+									.phoneNum(phoneNum)
+									.profileImg(profileImg)
+									.pushToken(pushToken)
+									.build());
+	}
+	
+	public void delete(Long id) {
+		findById(id).orElseThrow(() -> new InputValueValidationException("invalid user id"));
+		userRepository.deleteById(id);
+	}
+
 }

--- a/src/main/java/orangetaxiteam/cocoman/web/TokenController.java
+++ b/src/main/java/orangetaxiteam/cocoman/web/TokenController.java
@@ -1,0 +1,32 @@
+package orangetaxiteam.cocoman.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.ApiOperation;
+import orangetaxiteam.cocoman.application.UserApplicationService;
+import orangetaxiteam.cocoman.application.dto.UserDTO;
+import orangetaxiteam.cocoman.application.dto.UserSignInDTO;
+
+@RestController
+@RequestMapping("/api/token")
+public class TokenController {
+	
+private UserApplicationService userApplicationService;
+	
+	@Autowired
+	public TokenController(UserApplicationService userApplicationService) {
+		this.userApplicationService = userApplicationService;
+	}
+
+	@PostMapping
+	@ApiOperation(value = "Sign in with default account", tags = "User")
+	public @ResponseBody
+	UserDTO signIn(@RequestBody UserSignInDTO userSignInDTO) throws Exception { //Exception 수정 필요
+		return userApplicationService.signIn(userSignInDTO);
+	}
+}

--- a/src/main/java/orangetaxiteam/cocoman/web/UserController.java
+++ b/src/main/java/orangetaxiteam/cocoman/web/UserController.java
@@ -1,10 +1,13 @@
 package orangetaxiteam.cocoman.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +18,7 @@ import io.swagger.annotations.ApiOperation;
 import orangetaxiteam.cocoman.application.UserApplicationService;
 import orangetaxiteam.cocoman.application.dto.UserCreateRequestDTO;
 import orangetaxiteam.cocoman.application.dto.UserDTO;
-import orangetaxiteam.cocoman.application.dto.UserSignInDTO;
+import orangetaxiteam.cocoman.application.dto.UserUpdateRequestDTO;
 
 @RestController
 @RequestMapping("/api/user")
@@ -28,18 +31,41 @@ public class UserController {
 		this.userApplicationService = userApplicationService;
 	}
 	
-	@PostMapping(value = "/signUp")
+	@PostMapping
 	@ApiOperation(value = "Create new user", tags = "User")
 	public @ResponseBody
 	UserDTO signUp(@RequestBody UserCreateRequestDTO userCreateRequestDTO) throws Exception { //Exception 수정 필요
 		return userApplicationService.create(userCreateRequestDTO);
 	}
 	
-	@PostMapping(value = "/signIn")
-	@ApiOperation(value = "Signin", tags = "User")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "access token", required = true, dataType="String", paramType="header")
+	})
+	@GetMapping(value = "/{id}")
+	@ApiOperation(value = "Lookup one User", tags = "User")
 	public @ResponseBody
-	UserDTO signIn(@RequestBody UserSignInDTO userSignInDTO) throws Exception { //Exception 수정 필요
-		return userApplicationService.signIn(userSignInDTO);
+	UserDTO findById(@PathVariable Long id) {
+		return userApplicationService.findById(id);
+	}
+	
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "access token", required = true, dataType="String", paramType="header")
+	})
+	@PutMapping(value = "/{id}")
+	@ApiOperation(value = "Update User Info", tags = "User")
+	public @ResponseBody
+	UserDTO updateUser(@PathVariable Long id, @RequestBody UserUpdateRequestDTO userUpdateRequestDTO) {
+		return userApplicationService.updateUser(id, userUpdateRequestDTO);
+	}
+	
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "access token", required = true, dataType="String", paramType="header")
+	})
+	@DeleteMapping(value = "/{id}")
+	@ApiOperation(value = "Delete User Info", tags = "User")
+	public @ResponseBody
+	void deleteUser(@PathVariable Long id) {
+		userApplicationService.deleteUser(id);
 	}
 }
 


### PR DESCRIPTION

## Description
User 쪽 이슈에서 말씀하신 URL 형식으로 수정했습니다!
+User update와 delete 추가했습니다



## Discussion

- User update 할 때 update field를 한 번에 다 때려박아놨는데,, 저렇게 하는게 맞는건가요? 요청 url 생각하면 인자값을 다르게할 수 없을 거 같아서.. 프론트에서 수정 작업을 유저 정보 조회 후 -> 수정 이렇게 하니까 값을 다 전달 받을 수 있겠죠??
  뭔가 username이랑 password까지 전달받는게 이상해보여서 DTO 따로 만들고 username이랑 password는 user정보를 따로 찾아서 넣어줬는데,, 그냥 같이 받는게 나을까요..?

- Delete할 때 jpa repo 반환값이 void라 api도 void로 반환해버리게 했는데 어떻게 하는게 좋을까요큐큐ㅠㅠ 반환을 status만 해줘도 될 것 같아서?! 단일 반환값 DTO를 만들까요!?

- 아 그리고 Exception은 application 단에서 해줘야 하는 지도 궁금합니당