### PR TITLE
chore: implement example for domain driven design and spring

### DIFF
--- a/src/main/java/orangetaxiteam/cocoman/application/dto/CreateProfileRequest.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/CreateProfileRequest.java
@@ -1,0 +1,15 @@
+package orangetaxiteam.cocoman.application.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateProfileRequest {
+    private String name;
+    private Boolean isKid;
+    private String imageBinary;
+}

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/ProfileDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/ProfileDTO.java
@@ -1,0 +1,26 @@
+package orangetaxiteam.cocoman.application.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import orangetaxiteam.cocoman.domain.UserProfile;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileDTO {
+    private String id;
+    private String name;
+    private Boolean isKid;
+    private String imageBinary;
+
+    public static ProfileDTO of(UserProfile createdProfile, String imageBinary) {
+        return new ProfileDTO(
+                createdProfile.getId(),
+                createdProfile.getName(),
+                createdProfile.getIsKid(),
+                imageBinary
+        );
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/config/CocomanConfig.java
+++ b/src/main/java/orangetaxiteam/cocoman/config/CocomanConfig.java
@@ -1,0 +1,24 @@
+package orangetaxiteam.cocoman.config;
+
+import orangetaxiteam.cocoman.domain.ImageStorageService;
+import orangetaxiteam.cocoman.infra.AwsS3ImageStorageService;
+import orangetaxiteam.cocoman.infra.GcpImageStorageService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class CocomanConfig {
+    @Bean
+    public ImageStorageService awsS3ImageStorageService() {
+        return new AwsS3ImageStorageService();
+    }
+
+    @Bean
+    @Primary
+    @Profile({"gcp"})
+    public ImageStorageService gcpImageStorageService() {
+        return new GcpImageStorageService();
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/domain/ImageStorageService.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/ImageStorageService.java
@@ -1,0 +1,7 @@
+package orangetaxiteam.cocoman.domain;
+
+public interface ImageStorageService {
+    public String upload(String imageBinary);
+
+    public String download(String imagePath);
+}

--- a/src/main/java/orangetaxiteam/cocoman/domain/UserProfile.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/UserProfile.java
@@ -1,0 +1,43 @@
+package orangetaxiteam.cocoman.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "TB_USER_PROFILE")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProfile {
+    @Id
+    private String id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+    @Column
+    private String name;
+    @Column
+    private Boolean isKid;
+    @Column
+    private String imagePath;
+
+    private UserProfile(
+            String name,
+            Boolean isKid,
+            String imagePath
+    ) {
+        this.name = name;
+        this.isKid = isKid;
+        this.imagePath = imagePath;
+    }
+
+    public static UserProfile of(String name, Boolean isKid, String profileImagePath) {
+        return new UserProfile(name, isKid, profileImagePath);
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/domain/UserProfileRepository.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/UserProfileRepository.java
@@ -1,0 +1,17 @@
+package orangetaxiteam.cocoman.domain;
+
+import orangetaxiteam.cocoman.domain.exception.BadRequestException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, String> {
+    Optional<UserProfile> findByIdAndUser(String id, User user);
+
+    default UserProfile findByIdAndUserOrElseThrow(String id, User user) {
+        return this.findByIdAndUser(id, user)
+                .orElseThrow(() -> new BadRequestException(String.format("profile '%s' of user '%s' does not exist", id, user.getId())));
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/domain/exception/BadRequestException.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/exception/BadRequestException.java
@@ -1,0 +1,6 @@
+package orangetaxiteam.cocoman.domain.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String format) {
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/infra/AwsS3ImageStorageService.java
+++ b/src/main/java/orangetaxiteam/cocoman/infra/AwsS3ImageStorageService.java
@@ -1,0 +1,15 @@
+package orangetaxiteam.cocoman.infra;
+
+import orangetaxiteam.cocoman.domain.ImageStorageService;
+
+public class AwsS3ImageStorageService implements ImageStorageService {
+    @Override
+    public String upload(String imageBinary) {
+        return null;
+    }
+
+    @Override
+    public String download(String imagePath) {
+        return null;
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/infra/GcpImageStorageService.java
+++ b/src/main/java/orangetaxiteam/cocoman/infra/GcpImageStorageService.java
@@ -1,0 +1,15 @@
+package orangetaxiteam.cocoman.infra;
+
+import orangetaxiteam.cocoman.domain.ImageStorageService;
+
+public class GcpImageStorageService implements ImageStorageService {
+    @Override
+    public String upload(String imageBinary) {
+        return null;
+    }
+
+    @Override
+    public String download(String imagePath) {
+        return null;
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/web/UserController.java
+++ b/src/main/java/orangetaxiteam/cocoman/web/UserController.java
@@ -1,45 +1,55 @@
 package orangetaxiteam.cocoman.web;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-
 import orangetaxiteam.cocoman.application.UserApplicationService;
+import orangetaxiteam.cocoman.application.dto.CreateProfileRequest;
+import orangetaxiteam.cocoman.application.dto.ProfileDTO;
 import orangetaxiteam.cocoman.application.dto.UserCreateRequestDTO;
 import orangetaxiteam.cocoman.application.dto.UserDTO;
 import orangetaxiteam.cocoman.application.dto.UserSignInDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/api/v1/users")
 public class UserController {
+    private final UserApplicationService userApplicationService;
 
-	private UserApplicationService userApplicationService;
-	
-	@Autowired
-	public UserController(UserApplicationService userApplicationService) {
-		this.userApplicationService = userApplicationService;
-	}
-	
-	@PostMapping(value = "/signUp")
-	@ApiOperation(value = "Create new user", tags = "User")
-	public @ResponseBody
-	UserDTO signUp(@RequestBody UserCreateRequestDTO userCreateRequestDTO) throws Exception { //Exception 수정 필요
-		return userApplicationService.create(userCreateRequestDTO);
-	}
-	
-	@PostMapping(value = "/signIn")
-	@ApiOperation(value = "Signin", tags = "User")
-	public @ResponseBody
-	UserDTO signIn(@RequestBody UserSignInDTO userSignInDTO) throws Exception { //Exception 수정 필요
-		return userApplicationService.signIn(userSignInDTO);
-	}
+    public UserController(UserApplicationService userApplicationService) {
+        this.userApplicationService = userApplicationService;
+    }
+
+    @PostMapping(value = "/signUp")
+    @ApiOperation(value = "Create new user", tags = "User")
+    public @ResponseBody
+    UserDTO signUp(@RequestBody UserCreateRequestDTO userCreateRequestDTO) throws Exception { //Exception 수정 필요
+        return this.userApplicationService.create(userCreateRequestDTO);
+    }
+
+    @PostMapping(value = "/signIn")
+    @ApiOperation(value = "Signin", tags = "User")
+    public @ResponseBody
+    UserDTO signIn(@RequestBody UserSignInDTO userSignInDTO) throws Exception { //Exception 수정 필요
+        return this.userApplicationService.signIn(userSignInDTO);
+    }
+
+    @PostMapping(value = "/{userId}/profiles")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public ProfileDTO createProfile(@PathVariable String userId, @RequestBody CreateProfileRequest request) {
+        return this.userApplicationService.createUserProfile(userId, request);
+    }
+
+    @GetMapping(value = "/{userId}/profiles/{profileId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public ProfileDTO getProfile(@PathVariable String userId, @PathVariable String profileId) {
+        return this.userApplicationService.getUserProfile(userId, profileId);
+    }
 }
 


### PR DESCRIPTION
도메인 주도 설계(Domain Driven Design)나 스프링에 대해서 잘 모르시는 분들 참고하시라고 예시 하나 만들었습니다~
(merge 하지 말아주세요!)

### 사전 작업

1. 인텔리제이에서 save action 이라는 플러그인을 깔아주세요! 이 플러그인이 있으면 `cmd+s` 혹은 `ctrl+s` 할 때마다 자동으로 코드 포맷팅을 도와줍니다!
![image](https://user-images.githubusercontent.com/34789831/106786488-ef89ab00-6691-11eb-8fbb-7fa96e3c0cc7.png)
(save action 플러그인 설치 후 설정에서 다음처럼 세팅해주세요!)

2. import 할 때 보통 와일드카드를 이용해서(`import X.Y.Z.*`) import 하게 되어있는데요! 이는 사용하지 않는 클래스들도 모두 import 하기 때문에 이름 겹치는 클래스가 있을 때 실수를 유발할 수 있어서 좋지 않습니다. 해당 설정은 import 문이 몇개 이상일 때 와일드카드로 표시해줄지 설정하는 것인데 숫자를 엄청 많이 늘려주시면 됩니다~
![image](https://user-images.githubusercontent.com/34789831/106786644-1f38b300-6692-11eb-8b39-4af856b92448.png)
(class count to use ~, name count to use ~ 옵션의 숫자를 변경해주시면 됩니다. 저는 100개정도로 해둡니다 ㅎㅎ)


### 시나리오

저희가 실제로 개발하고 있는 서비스의 기능 중에서 적당한 예시를 못찾겠어서 그냥 임의로 예시를 하나 만들었어요.

OTT 서비스 사용해보시면 아시겠지만 보통 한 계정에 여러 프로필이 존재하는데 이를 `UserProfile`이라는 클래스로 표현해봤어요. 그래서 프로필을 생성하거나 조회하는 API를 구현해보았습니다.

특이사항은 `한 계정당 4개가 넘는 프로필을 만들 수는 없다`는 것입니다!


### 기타

자세한 코드 내용은 해당 PR의 코멘트로 남겨놓을게요~!