### PR TITLE
feat: Add rate plan entity

### DIFF
--- a/src/main/java/orangetaxiteam/cocoman/application/OttApplicationService.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/OttApplicationService.java
@@ -44,6 +44,13 @@ public class OttApplicationService extends PaginationFinder {
         );
     }
 
+    @Transactional(readOnly = true)
+    public Pagination<RatePlanDTO> findRatePlanForOtt(Pageable pageable, String ott) {
+        return this.findAll(() -> this.ratePlanRepository.findByOtt(ott, pageable)
+                .map(RatePlanDTO::from)
+        );
+    }
+
     @Transactional
     public OttDTO create(OttCreateRequestDTO ottCreateRequestDTO) {
         return OttDTO.from(

--- a/src/main/java/orangetaxiteam/cocoman/application/OttApplicationService.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/OttApplicationService.java
@@ -2,6 +2,8 @@ package orangetaxiteam.cocoman.application;
 
 import orangetaxiteam.cocoman.application.dto.OttCreateRequestDTO;
 import orangetaxiteam.cocoman.application.dto.OttDTO;
+import orangetaxiteam.cocoman.application.dto.RatePlanDTO;
+import orangetaxiteam.cocoman.domain.RatePlanRepository;
 import orangetaxiteam.cocoman.domain.Ott;
 import orangetaxiteam.cocoman.domain.OttRepository;
 import orangetaxiteam.cocoman.domain.Pagination;
@@ -16,13 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class OttApplicationService extends PaginationFinder {
     private final OttRepository ottRepository;
+    private final RatePlanRepository ratePlanRepository;
 
     public OttApplicationService(
             PaginationFactory paginationFactory,
-            OttRepository ottRepository
+            OttRepository ottRepository,
+            RatePlanRepository ratePlanRepository
     ) {
         super(paginationFactory);
         this.ottRepository = ottRepository;
+        this.ratePlanRepository = ratePlanRepository;
     }
 
     @Transactional(readOnly = true)
@@ -32,13 +37,19 @@ public class OttApplicationService extends PaginationFinder {
         );
     }
 
+    @Transactional(readOnly = true)
+    public Pagination<RatePlanDTO> findRatePlan(Pageable pageable) {
+        return this.findAll(() -> this.ratePlanRepository.findAll(pageable)
+                .map(RatePlanDTO::from)
+        );
+    }
+
     @Transactional
     public OttDTO create(OttCreateRequestDTO ottCreateRequestDTO) {
         return OttDTO.from(
                 this.ottRepository.save(Ott.of(
                         ottCreateRequestDTO.getName(),
                         ottCreateRequestDTO.getImagePath(),
-                        ottCreateRequestDTO.getRatePlan(),
                         ottCreateRequestDTO.getContentsSet()
                 ))
         );

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/OttDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/OttDTO.java
@@ -15,7 +15,6 @@ public class OttDTO {
     private String id;
     private String name;
     private String imagePath;
-    private String ratePlan;
     private List<ContentsDTO> contentsList;
 
     public static OttDTO from(Ott ott) {
@@ -24,7 +23,6 @@ public class OttDTO {
         ottDTO.id = ott.getId();
         ottDTO.name = ott.getName();
         ottDTO.imagePath = ott.getImagePath();
-        ottDTO.ratePlan = ott.getRatePlan();
         ottDTO.contentsList = ott.getContentsSet()
                 .stream()
                 .map(ContentsDTO::from)

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/RatePlanDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/RatePlanDTO.java
@@ -1,0 +1,32 @@
+package orangetaxiteam.cocoman.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import orangetaxiteam.cocoman.domain.RatePlan;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RatePlanDTO {
+    private String id;
+    private String name;
+    private String cost;
+    private String resolution;
+    private int simultaneousAccess;
+    private String ottId;
+
+    public static RatePlanDTO from(RatePlan ratePlan){
+        RatePlanDTO ratePlanDTO = new RatePlanDTO();
+        ratePlanDTO.id = ratePlan.getId();
+        ratePlanDTO.name = ratePlan.getName();
+        ratePlanDTO.cost = ratePlan.getCost();
+        ratePlanDTO.resolution = ratePlan.getResolution();
+        ratePlanDTO.simultaneousAccess = ratePlan.getSimultaneousAccess();
+        ratePlanDTO.ottId = ratePlan.getOtt().getId();
+
+        return ratePlanDTO;
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/RatePlanDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/RatePlanDTO.java
@@ -15,7 +15,7 @@ public class RatePlanDTO {
     private String name;
     private String cost;
     private String resolution;
-    private int simultaneousAccess;
+    private Integer numOfScreens;
     private String ottId;
 
     public static RatePlanDTO from(RatePlan ratePlan){
@@ -24,7 +24,7 @@ public class RatePlanDTO {
         ratePlanDTO.name = ratePlan.getName();
         ratePlanDTO.cost = ratePlan.getCost();
         ratePlanDTO.resolution = ratePlan.getResolution();
-        ratePlanDTO.simultaneousAccess = ratePlan.getSimultaneousAccess();
+        ratePlanDTO.numOfScreens = ratePlan.getNumOfScreens();
         ratePlanDTO.ottId = ratePlan.getOtt().getId();
 
         return ratePlanDTO;

--- a/src/main/java/orangetaxiteam/cocoman/application/dto/RatePlanDTO.java
+++ b/src/main/java/orangetaxiteam/cocoman/application/dto/RatePlanDTO.java
@@ -15,7 +15,7 @@ public class RatePlanDTO {
     private String name;
     private String cost;
     private String resolution;
-    private Integer numOfScreens;
+    private Integer maxSimultaneous;
     private String ottId;
 
     public static RatePlanDTO from(RatePlan ratePlan){
@@ -24,7 +24,7 @@ public class RatePlanDTO {
         ratePlanDTO.name = ratePlan.getName();
         ratePlanDTO.cost = ratePlan.getCost();
         ratePlanDTO.resolution = ratePlan.getResolution();
-        ratePlanDTO.numOfScreens = ratePlan.getNumOfScreens();
+        ratePlanDTO.maxSimultaneous = ratePlan.getMaxSimultaneous();
         ratePlanDTO.ottId = ratePlan.getOtt().getId();
 
         return ratePlanDTO;

--- a/src/main/java/orangetaxiteam/cocoman/config/InitDummyData.java
+++ b/src/main/java/orangetaxiteam/cocoman/config/InitDummyData.java
@@ -1,19 +1,7 @@
 package orangetaxiteam.cocoman.config;
 
 
-import orangetaxiteam.cocoman.domain.StarRatingRepository;
-import orangetaxiteam.cocoman.domain.StarRating;
-import orangetaxiteam.cocoman.domain.User;
-import orangetaxiteam.cocoman.domain.UserRepository;
-import orangetaxiteam.cocoman.domain.Contents;
-import orangetaxiteam.cocoman.domain.ContentsRepository;
-import orangetaxiteam.cocoman.domain.Genre;
-import orangetaxiteam.cocoman.domain.GenreRepository;
-import orangetaxiteam.cocoman.domain.Review;
-import orangetaxiteam.cocoman.domain.ReviewRepository;
-import orangetaxiteam.cocoman.domain.Ott;
-import orangetaxiteam.cocoman.domain.OttRepository;
-import orangetaxiteam.cocoman.domain.Gender;
+import orangetaxiteam.cocoman.domain.*;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +19,7 @@ public class InitDummyData implements CommandLineRunner {
     private GenreRepository genreRepository;
     private ReviewRepository reviewRepository;
     private OttRepository ottRepository;
+    private RatePlanRepository ratePlanRepository;
 
     public InitDummyData(
             UserRepository userRepository,
@@ -38,7 +27,8 @@ public class InitDummyData implements CommandLineRunner {
             StarRatingRepository starRatingRepository,
             GenreRepository genreRepository,
             ReviewRepository reviewRepository,
-            OttRepository ottRepository
+            OttRepository ottRepository,
+            RatePlanRepository ratePlanRepository
     ) {
         this.userRepository = userRepository;
         this.contentsRepository = contentsRepository;
@@ -46,6 +36,7 @@ public class InitDummyData implements CommandLineRunner {
         this.genreRepository = genreRepository;
         this.reviewRepository = reviewRepository;
         this.ottRepository = ottRepository;
+        this.ratePlanRepository = ratePlanRepository;
     }
 
     @Override
@@ -55,6 +46,7 @@ public class InitDummyData implements CommandLineRunner {
         List<Contents> contentsList = this.insertDummyContents(genreList);
         List<Ott> ottList = this.insertDummyOtts(contentsList);
 
+        this.insertDummyRatePlan(ottList);
         this.insertDummyStarRating(contentsList);
         this.insertDummyReview(contentsList, userList);
     }
@@ -167,13 +159,40 @@ public class InitDummyData implements CommandLineRunner {
                     Ott.of(
                             "Netflix",
                             "",
-                            "basic: 9500₩, standard: 13500₩, premium: 17000₩",
                             netflixContents
                     )
             ));
         }
 
         return ottList;
+    }
+
+    private void insertDummyRatePlan(List<Ott> ottList){
+        if (this.ratePlanRepository.findAll().isEmpty()) {
+            this.ratePlanRepository.save(RatePlan.of(
+                    "Basic",
+                    "9,500￦",
+                    "SD(480p)",
+                    1,
+                    ottList.get(0)
+            ));
+
+            this.ratePlanRepository.save(RatePlan.of(
+                    "Standard",
+                    "13,500￦",
+                    "HD(1080p)",
+                    2,
+                    ottList.get(0)
+            ));
+
+            this.ratePlanRepository.save(RatePlan.of(
+                    "Premium",
+                    "17,000￦",
+                    "UHD(2160p)+HDR",
+                    4,
+                    ottList.get(0)
+            ));
+        }
     }
 
     private void insertDummyStarRating(List<Contents> contentsList) {

--- a/src/main/java/orangetaxiteam/cocoman/config/InitDummyData.java
+++ b/src/main/java/orangetaxiteam/cocoman/config/InitDummyData.java
@@ -1,7 +1,22 @@
 package orangetaxiteam.cocoman.config;
 
 
-import orangetaxiteam.cocoman.domain.*;
+import orangetaxiteam.cocoman.domain.StarRatingRepository;
+import orangetaxiteam.cocoman.domain.StarRating;
+import orangetaxiteam.cocoman.domain.User;
+import orangetaxiteam.cocoman.domain.UserRepository;
+import orangetaxiteam.cocoman.domain.Contents;
+import orangetaxiteam.cocoman.domain.ContentsRepository;
+import orangetaxiteam.cocoman.domain.Genre;
+import orangetaxiteam.cocoman.domain.GenreRepository;
+import orangetaxiteam.cocoman.domain.Review;
+import orangetaxiteam.cocoman.domain.ReviewRepository;
+import orangetaxiteam.cocoman.domain.Ott;
+import orangetaxiteam.cocoman.domain.OttRepository;
+import orangetaxiteam.cocoman.domain.Gender;
+import orangetaxiteam.cocoman.domain.RatePlan;
+import orangetaxiteam.cocoman.domain.RatePlanRepository;
+
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/orangetaxiteam/cocoman/domain/Ott.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/Ott.java
@@ -21,9 +21,6 @@ public class Ott extends DomainEntity {
     @Column(name = "image_path")
     private String imagePath;
 
-    @Column(name = "rate_plan")
-    private String ratePlan;
-
     @ManyToMany
     @JoinColumn(name = "contents")
     private Set<Contents> contentsSet;
@@ -32,27 +29,23 @@ public class Ott extends DomainEntity {
             String id,
             String name,
             String imagePath,
-            String ratePlan,
             Set<Contents> contentsSet
     ) {
         super(id);
         this.name = name;
         this.imagePath = imagePath;
-        this.ratePlan = ratePlan;
         this.contentsSet = contentsSet;
     }
 
     public static Ott of(
             String name,
             String imagePath,
-            String ratePlan,
             Set<Contents> contentsSet
     ) {
         return new Ott(
                 null,
                 name,
                 imagePath,
-                ratePlan,
                 contentsSet
         );
     }

--- a/src/main/java/orangetaxiteam/cocoman/domain/RatePlan.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/RatePlan.java
@@ -1,0 +1,45 @@
+package orangetaxiteam.cocoman.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "TB_RATE_PLAN")
+public class RatePlan extends DomainEntity {
+    @Column(length = 50)
+    private String name;
+
+    @Column(length = 50)
+    private String cost;
+
+    @Column(length = 50)
+    private String resolution;
+
+    @Column
+    private Integer simultaneousAccess;
+
+    @ManyToOne
+    @JoinColumn(name = "ott")
+    private Ott ott;
+
+    private RatePlan(String id, String name, String cost, String resolution, int simultaneousAccess, Ott ott) {
+        super(id);
+        this.name = name;
+        this.cost = cost;
+        this.resolution = resolution;
+        this.simultaneousAccess = simultaneousAccess;
+        this.ott = ott;
+    }
+
+    public static RatePlan of(String name, String cost, String resolution, int simultaneousAccess, Ott ott) {
+        return new RatePlan(null, name, cost, resolution, simultaneousAccess, ott);
+    }
+}

--- a/src/main/java/orangetaxiteam/cocoman/domain/RatePlan.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/RatePlan.java
@@ -24,22 +24,22 @@ public class RatePlan extends DomainEntity {
     private String resolution;
 
     @Column
-    private Integer numOfScreens;
+    private Integer maxSimultaneous;
 
     @ManyToOne
     @JoinColumn(name = "ott")
     private Ott ott;
 
-    private RatePlan(String id, String name, String cost, String resolution, Integer numOfScreens, Ott ott) {
+    private RatePlan(String id, String name, String cost, String resolution, Integer maxSimultaneous, Ott ott) {
         super(id);
         this.name = name;
         this.cost = cost;
         this.resolution = resolution;
-        this.numOfScreens = numOfScreens;
+        this.maxSimultaneous = maxSimultaneous;
         this.ott = ott;
     }
 
-    public static RatePlan of(String name, String cost, String resolution, Integer numOfScreens, Ott ott) {
-        return new RatePlan(null, name, cost, resolution, numOfScreens, ott);
+    public static RatePlan of(String name, String cost, String resolution, Integer maxSimultaneous, Ott ott) {
+        return new RatePlan(null, name, cost, resolution, maxSimultaneous, ott);
     }
 }

--- a/src/main/java/orangetaxiteam/cocoman/domain/RatePlan.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/RatePlan.java
@@ -24,22 +24,22 @@ public class RatePlan extends DomainEntity {
     private String resolution;
 
     @Column
-    private Integer simultaneousAccess;
+    private Integer numOfScreens;
 
     @ManyToOne
     @JoinColumn(name = "ott")
     private Ott ott;
 
-    private RatePlan(String id, String name, String cost, String resolution, int simultaneousAccess, Ott ott) {
+    private RatePlan(String id, String name, String cost, String resolution, Integer numOfScreens, Ott ott) {
         super(id);
         this.name = name;
         this.cost = cost;
         this.resolution = resolution;
-        this.simultaneousAccess = simultaneousAccess;
+        this.numOfScreens = numOfScreens;
         this.ott = ott;
     }
 
-    public static RatePlan of(String name, String cost, String resolution, int simultaneousAccess, Ott ott) {
-        return new RatePlan(null, name, cost, resolution, simultaneousAccess, ott);
+    public static RatePlan of(String name, String cost, String resolution, Integer numOfScreens, Ott ott) {
+        return new RatePlan(null, name, cost, resolution, numOfScreens, ott);
     }
 }

--- a/src/main/java/orangetaxiteam/cocoman/domain/RatePlanRepository.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/RatePlanRepository.java
@@ -1,8 +1,14 @@
 package orangetaxiteam.cocoman.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
 
 @Repository
 public interface RatePlanRepository extends JpaRepository<RatePlan, String> {
+    @Query(value = "SELECT s FROM RatePlan s WHERE s.ott.id = :ott ORDER BY s.numOfScreens ASC")
+    Page<RatePlan> findByOtt(String ott, Pageable pageable);
 }

--- a/src/main/java/orangetaxiteam/cocoman/domain/RatePlanRepository.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/RatePlanRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RatePlanRepository extends JpaRepository<RatePlan, String> {
-    @Query(value = "SELECT s FROM RatePlan s WHERE s.ott.id = :ott ORDER BY s.numOfScreens ASC")
+    @Query(value = "SELECT s FROM RatePlan s WHERE s.ott.id = :ott ORDER BY s.maxSimultaneous ASC")
     Page<RatePlan> findByOtt(String ott, Pageable pageable);
 }

--- a/src/main/java/orangetaxiteam/cocoman/domain/RatePlanRepository.java
+++ b/src/main/java/orangetaxiteam/cocoman/domain/RatePlanRepository.java
@@ -1,0 +1,8 @@
+package orangetaxiteam.cocoman.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RatePlanRepository extends JpaRepository<RatePlan, String> {
+}

--- a/src/main/java/orangetaxiteam/cocoman/web/OttController.java
+++ b/src/main/java/orangetaxiteam/cocoman/web/OttController.java
@@ -2,6 +2,7 @@ package orangetaxiteam.cocoman.web;
 
 import orangetaxiteam.cocoman.application.OttApplicationService;
 import orangetaxiteam.cocoman.application.dto.OttDTO;
+import orangetaxiteam.cocoman.application.dto.RatePlanDTO;
 import orangetaxiteam.cocoman.domain.Pagination;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -38,4 +39,11 @@ public class OttController {
         return ottApplicationService.findById(id);
     }
 
+    @GetMapping(value = "/ratePlan")
+    @ResponseStatus(value = HttpStatus.OK)
+    public Pagination<RatePlanDTO> findRatePlan(
+            @SortDefault(sort = "createdAt", direction = Sort.Direction.ASC) @PageableDefault(size = 15) final Pageable pageable
+    ) {
+        return ottApplicationService.findRatePlan(pageable);
+    }
 }

--- a/src/main/java/orangetaxiteam/cocoman/web/OttController.java
+++ b/src/main/java/orangetaxiteam/cocoman/web/OttController.java
@@ -39,6 +39,15 @@ public class OttController {
         return ottApplicationService.findById(id);
     }
 
+    @GetMapping(value = "/{id}/ratePlan")
+    @ResponseStatus(value = HttpStatus.OK)
+    public Pagination<RatePlanDTO> findRatePlanForOtt(
+            @SortDefault(sort = "createdAt", direction = Sort.Direction.ASC) @PageableDefault(size = 15) final Pageable pageable,
+            @PathVariable String id
+    ) {
+        return ottApplicationService.findRatePlanForOtt(pageable, id);
+    }
+
     @GetMapping(value = "/ratePlan")
     @ResponseStatus(value = HttpStatus.OK)
     public Pagination<RatePlanDTO> findRatePlan(


### PR DESCRIPTION
요금제 테이블을 추가했습니다. 컬럼은 다음과 같습니다.
id - PK
name 
cost 
resolution
simultaneousAccess
ottId - FK

포스트맨에서
get => localhost:8080/api/v1/ott/ratePlan 으로 목록을 확인하실 수 있습니다.

테이블이 추가됨에 따라 Ott에서 rateplan 컬럼을 제거했습니다.